### PR TITLE
fix the brush selection handler

### DIFF
--- a/16-Interactive-graphics/08-brushing.R
+++ b/16-Interactive-graphics/08-brushing.R
@@ -11,7 +11,7 @@ server <- function(input, output) {
   })
 
   output$info <- renderPrint({
-    rows <- brushedPoints(mtcars, input$plot_brush)
+    rows <- brushedPoints(mtcars, input$brush)
     cat("Brushed points:\n")
     print(rows)
   })


### PR DESCRIPTION
since the brush selector is named as "brush" in the plotOutput object in ui.R, it need to be referred consistently in the renderPrint reactive function in server.R, otherwise it won't work, in my case.