### PR TITLE
inside flevels(): fct_reorder() argument is called .x  (not x)

### DIFF
--- a/54-row-oriented-work/iterate-over-rows.R
+++ b/54-row-oriented-work/iterate-over-rows.R
@@ -98,7 +98,7 @@ run_col_benchmark <- function(ncol, times = 5) {
 
 ## force figs to present methods in order of time
 flevels <- function(df) {
-  mutate(df, method = fct_reorder(method, x = desc(time)))
+  mutate(df, method = fct_reorder(method, .x = desc(time)))
 }
 
 plot_it <- function(df, what = "nrow") {


### PR DESCRIPTION
With "x" I encountered this error message:
   
    mutate(df_r, method = fct_reorder(method, x = desc(time)))
    Error in mutate_impl(.data, dots) : 
      Evaluation error: argument ".x" is missing, with no default.